### PR TITLE
pass options/withDefaults to coffee-jshint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ grunt.initConfig({
 
 ### Options
 
+#### options.jshintOptions
+Type: `Array`
+Default value: `[]`
+
+A list of options for coffee-jshint.
+For more informations, please see coffee-jshint's [Options](https://github.com/Clever/coffee-jshint#options)
+
+#### options.withDefaults
+Type: `Boolean`
+Default value: `true`
+
+If you want to turn off the default options for coffee-jshint, change this flag to `false`.
+For more informations, please see coffee-jshint's [Options](https://github.com/Clever/coffee-jshint#options)
+
 #### options.globals
 Type: `Array`
 Default value: `[]`

--- a/tasks/coffee_jshint.js
+++ b/tasks/coffee_jshint.js
@@ -19,6 +19,8 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('coffee_jshint', 'grunt wrapper for coffee-jshint', function() {
         // Merge task-specific and/or target-specific options with these defaults.
         var options = this.options({
+            jshintOptions: [],
+            withDefaults: true,
             globals: []
         });
         var files = this.filesSrc;
@@ -37,8 +39,8 @@ module.exports = function(grunt) {
     var hintFile = function(path, options) {
 
         var errors = hintFiles([path],
-                               {options: [],
-                                withDefaults: true,
+                               {options: options.jshintOptions,
+                                withDefaults: options.withDefaults,
                                 globals: options.globals},
                                false);
         var flattened_errors = [].concat.apply([], errors);


### PR DESCRIPTION
I want to use coffee-jshint options such as 'browser', then I created little patch.
Could you merge this?

example block of Gruntfile.js:

``` javascript
    coffee_jshint: {
      libs: {
        options: {
          jshintOptions: [ 'browser', 'jquery' ],
          withDefaults: true,
          globals: [ 'MyObject1', 'MyObject2' ]
        },
        src: 'coffee/**/*.coffee'
      }
    }
```

> You can set withDefaults:false, but now coffee-jshint has a bug with this option. 
