### PR TITLE
Dependency update, a fix and other chores

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "coffee-jshint": "0.0.14"
+    "coffee-jshint": "^0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/bmac/grunt-coffee-jshint/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/bmac/grunt-coffee-jshint/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.0"

--- a/tasks/coffee_jshint.js
+++ b/tasks/coffee_jshint.js
@@ -27,10 +27,11 @@ module.exports = function(grunt) {
 
         var errors = files.map(function(path) {
             return hintFile(path, options);
+        }).filter( function(file_errors) {
+            return file_errors !== ''
         });
-         
-        var hasErrors = (/:/.test('\n' + errors.join('\n\n') + '\n'));
-        if (hasErrors) {
+
+        if (errors.length) {
             grunt.fail.warn('\n' + errors.join('\n\n') + '\n');
         }
 


### PR DESCRIPTION
@bmac, as per your request in #6 this PR upgrades the dependency on `coffee-jshint` to its latest incarnation. Please note that the change is from a fixed `0.0.14` to a `^0.2.3` version _range_.

I have left upgrading the `devDependencies` and `peerDependencies` to your discretion. I tried taking your `Gruntfile` for a spin, but I fear that some of the project state has never departed from the initial gruntplugin template defaults, so I could not get that to do anything meaningful.

I did however fix the `.jshintrc` rules and the `licenses` entry in the `package.json`, because both `jshint` and `npm` respectively kept complaining about these:

```
Linting ... ERROR
>> ES5 option is now set per default
```
```
npm WARN package.json grunt-coffee-jshint@0.2.1 No license field.
```

Note that there is a slight semantic difference in how the license was expressed before and after. Please check wether this bothers you.  

Finally, I took the liberty of fixing the small nuisance that when there were errors to report for some files, an additional empty line got sent to the output per each file tested that had none.